### PR TITLE
GH-3 | Lazy load print jobs history table

### DIFF
--- a/octoprint_PrintJobHistory/static/js/PrintJobHistory-APIClient.js
+++ b/octoprint_PrintJobHistory/static/js/PrintJobHistory-APIClient.js
@@ -86,7 +86,7 @@ function PrintJobHistoryAPIClient(pluginId, baseUrl) {
     this.callLoadPrintJobsByQuery = function (tableQuery, responseHandler){
         query = _buildRequestQuery(tableQuery);
         urlToCall = this.baseUrl + "plugin/"+this.pluginId+"/loadPrintJobHistoryByQuery?"+query;
-        $.ajax({
+        return $.ajax({
             //url: API_BASEURL + "plugin/"+PLUGIN_ID+"/loadPrintJobHistory",
             url: urlToCall,
             type: "GET"

--- a/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
+++ b/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
@@ -420,7 +420,7 @@ $(function() {
             }
             var storageKey = "pjh.table.selectedPageSize";
             if (localStorage[storageKey] == null){
-                localStorage[storageKey] = "25"; // default page size
+                localStorage[storageKey] = `${DEFAULT_TABLE_PAGE_SIZE}`;
             } else {
                 self.printJobHistoryTableHelper.selectedPageSize(Number(localStorage[storageKey]));
             }

--- a/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
+++ b/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
@@ -5,6 +5,8 @@
  * License: AGPLv3
  */
 
+const TABS_CONTENT_SELECTOR = "#tabs_content";
+const PLUGIN_TAB_SELECTOR = "#tab_plugin_PrintJobHistory";
 const DEFAULT_TABLE_PAGE_SIZE = 10;
 
 $(function() {
@@ -733,14 +735,14 @@ $(function() {
                     self.printJobHistoryTableHelper.toggleIsInBackground(!intersectionEntry.isIntersecting);
                 },
                 {
-                    root: document.querySelector("#tabs_content"),
+                    root: document.querySelector(TABS_CONTENT_SELECTOR),
                     rootMargin: "0px",
                     threshold: 0.0001,
                 },
             );
 
             tabVisibilityObserver.observe(
-                document.querySelector("#tab_plugin_PrintJobHistory"),
+                document.querySelector(PLUGIN_TAB_SELECTOR),
             );
         }
 
@@ -854,9 +856,8 @@ $(function() {
             }
         }
 
-        self.onTabChange = function(next, current){
-            //alert("Next:"+next +" Current:"+current);
-            if ("#tab_plugin_PrintJobHistory" == next){
+        self.onTabChange = function(next, current) {
+            if (PLUGIN_TAB_SELECTOR == next) {
                 //self.reloadTableData();
             }
         }

--- a/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
+++ b/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
@@ -455,6 +455,13 @@ $(function() {
 
         ///////////////////////////////////////////////////// START: SETTINGS
         self.busyIndicatorActive = ko.observable(false);
+        self.isLoadingTablePage = ko.observable(false);
+
+        // Note: for some reason, Knockout binding acts up with two bindings using the same variable...
+        // Computed variable with flipped value solves the issue
+        self.isNotLoadingTablePage = ko.computed(() => {
+            return !self.isLoadingTablePage();
+        });
 
         self.downloadDatabaseUrl = ko.observable();
         self.cameraSnapShotURLAvailable = ko.observable(false);
@@ -978,6 +985,8 @@ $(function() {
 
 
         loadJobFunction = function(tableQuery, observableTableModel, observableTotalItemCount, observableCurrentItemCount){
+            self.isLoadingTablePage(true);
+
             // api-call
             self.apiClient.callLoadPrintJobsByQuery(tableQuery, function(responseData){
                 // handle response
@@ -990,6 +999,9 @@ $(function() {
                 observableCurrentItemCount(dataRows.length);
                 observableTableModel(dataRows);
 
+                self.isLoadingTablePage(false);
+            }).catch(() => {
+                self.isLoadingTablePage(false);
             });
         }
 

--- a/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
+++ b/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
@@ -728,7 +728,20 @@ $(function() {
                 self.confirmMessageDialogData = null;
             }
 
+            const tabVisibilityObserver = new IntersectionObserver(
+                ([ intersectionEntry ]) => {
+                    self.printJobHistoryTableHelper.toggleIsInBackground(!intersectionEntry.isIntersecting);
+                },
+                {
+                    root: document.querySelector("#tabs_content"),
+                    rootMargin: "0px",
+                    threshold: 0.0001,
+                },
+            );
 
+            tabVisibilityObserver.observe(
+                document.querySelector("#tab_plugin_PrintJobHistory"),
+            );
         }
 
         self.onUserLoggedIn = function(currentUser) {

--- a/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
+++ b/octoprint_PrintJobHistory/static/js/PrintJobHistory.js
@@ -4,6 +4,9 @@
  * Author: OllisGit
  * License: AGPLv3
  */
+
+const DEFAULT_TABLE_PAGE_SIZE = 10;
+
 $(function() {
 
     ////////////////////////////////////////////////////////////
@@ -976,7 +979,12 @@ $(function() {
             });
         }
 
-        self.printJobHistoryTableHelper = new PrintJobTableItemHelper(loadJobFunction, 25, "printStartDateTime", "all");
+        self.printJobHistoryTableHelper = new PrintJobTableItemHelper(
+            loadJobFunction,
+            DEFAULT_TABLE_PAGE_SIZE,
+            "printStartDateTime",
+            "all",
+        );
 
         // - timeframe query
         self.allTimeFrames = ko.observableArray([

--- a/octoprint_PrintJobHistory/static/js/TableItemHelper.js
+++ b/octoprint_PrintJobHistory/static/js/TableItemHelper.js
@@ -8,6 +8,11 @@
 
     var self = this;
 
+    let isInBackground = true;
+    const scheduledTasks = {
+        _loadItems: undefined,
+    };
+
     self.loadItemsFunction = loadItemsFunction;
     self.items = ko.observableArray([]);
     self.totalItemCount = ko.observable(0);
@@ -53,9 +58,19 @@
     }
 
     // ############################################################################################### private functions
-    self._loadItems = function(){
-        var tableQuery = self.getTableQuery();
-        self.loadItemsFunction( tableQuery, self.items, self.totalItemCount, self.currentItemCount );
+    self._loadItems = function() {
+        const task = () => {
+            var tableQuery = self.getTableQuery();
+            self.loadItemsFunction( tableQuery, self.items, self.totalItemCount, self.currentItemCount );
+        };
+
+        if (!isInBackground) {
+            task();
+
+            return;
+        }
+
+        scheduledTasks._loadItems = task;
     }
 
     self.getTableQuery = function(){
@@ -100,6 +115,22 @@
         self.selectedTableItems.removeAll();
         self._loadItems();
     }
+
+
+    self.toggleIsInBackground = (setIsInBackground) => {
+        if (setIsInBackground === isInBackground) {
+            return;
+        }
+
+        isInBackground = setIsInBackground;
+
+        if (setIsInBackground) {
+            return;
+        }
+
+        scheduledTasks._loadItems?.();
+        scheduledTasks._loadItems = undefined;
+    };
 
 
     self.paginatedItems = ko.dependentObservable(function() {

--- a/octoprint_PrintJobHistory/templates/PrintJobHistory_tab.jinja2
+++ b/octoprint_PrintJobHistory/templates/PrintJobHistory_tab.jinja2
@@ -306,8 +306,11 @@
     </div>
     <!-- END: PAGEINATION BLOCK    -->
 
+    <div data-bind="visible: isLoadingTablePage" style="margin: 16px; text-align: center;">
+        <i class='fa fa-2xl fa-spinner fa-spin' ></i>
+    </div>
 
-    <table id="printjobhistory_main_table" class="table table-striped table-hover table-condensed table-hover" style="clear: both;">
+    <table id="printjobhistory_main_table" class="table table-striped table-hover table-condensed table-hover" style="clear: both;" data-bind="visible: isNotLoadingTablePage">
         <thead>
             <tr>
 <!--                <th style="width: 4%; text-align: center;" ><input type="checkbox" data-bind="checked:$root.printJobHistoryTableHelper.allSelected"></th>-->


### PR DESCRIPTION
Closes #3 

### Changelog
- [x] Introduce jobs table lazy loading
- [x] Add table page loading spinner
- [ ] Make lazy loading toggleable

### Benchmarks

#### Octoprint startup time

- Until everything is loaded
- Test repeated 5 times after initial hard reload & stabilisation
- Test performed on OrangePi Zero 2, Armbian build 2023-06-21

| - | Before | After | Δ |
|--------|--------|--------|--------|
| Load time (avg) | 5,766 s | 5,38 s | -0,386 s |